### PR TITLE
Fixes for current versions of chisel and firrtl.

### DIFF
--- a/src/main/scala/Util.scala
+++ b/src/main/scala/Util.scala
@@ -12,6 +12,7 @@ class Ready[+T <: Data](gen: T) extends Bundle {
     val ready = Input(Bool())
     val bits = Output(gen)
     def fire: Bool = ready
+    override def cloneType(): this.type = new Ready(gen).asInstanceOf[this.type]
 }
 
 

--- a/src/main/scala/unittest/Generator.scala
+++ b/src/main/scala/unittest/Generator.scala
@@ -5,7 +5,7 @@ import freechips.rocketchip.config.{Parameters, Config}
 import freechips.rocketchip.util.{HasGeneratorUtilities, ParsedInputNames}
 import java.io.{File, FileWriter}
 import net.jcazevedo.moultingyaml._
-import firrtl.annotations.AnnotationYamlProtocol._
+import firrtl.annotations.JsonProtocol
 
 trait GeneratorApp extends App with HasGeneratorUtilities {
   lazy val names = ParsedInputNames(
@@ -34,7 +34,7 @@ trait GeneratorApp extends App with HasGeneratorUtilities {
   def generateAnno {
     val annoFile = new File(names.targetDir, s"$longName.anno")
     val afw = new FileWriter(annoFile)
-    afw.write(circuit.annotations.toArray.toYaml.prettyPrint)
+    afw.write(JsonProtocol.serialize(circuit.annotations.map(_.toFirrtl)))
     afw.close()
   }
 }


### PR DESCRIPTION
Firrtl (or at least rocketchip) has moved to JSON over YAML. Also, new chisel autoCloneType seems to interact with Ready() in a strange way. Not a big problem if you don't want to merge because of your current versions of things, but it's nice for me to have this branch hanging around to merge into my working branches. @grebe 