### PR TITLE
Make data factory parameter vals so cloneType can be inferred

### DIFF
--- a/src/main/scala/FixedWidthPacketization.scala
+++ b/src/main/scala/FixedWidthPacketization.scala
@@ -6,7 +6,7 @@ import chisel3.util._
 // TODO get rid of this rocketchip dependency
 import freechips.rocketchip.util.{AsyncQueue, AsyncQueueParams}
 
-class FixedWidthData[F <: Data](factory: () => F) extends Bundle {
+class FixedWidthData[F <: Data](val factory: () => F) extends Bundle {
     val tx = Flipped(Decoupled(factory()))
     val rx = Decoupled(factory())
 }

--- a/src/main/scala/Lane.scala
+++ b/src/main/scala/Lane.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental._
 
-final class LaneIO[T <: Data](dataFactory: () => T)(implicit val c: SerDesConfig)
+final class LaneIO[T <: Data](val dataFactory: () => T)(implicit val c: SerDesConfig)
     extends Bundle with TransceiverOuterIF {
     val data = dataFactory()
     val txClock = Output(Clock())


### PR DESCRIPTION
To fix the error:
`[error] Caused by: chisel3.core.AutoClonetypeException: Unable to automatically infer cloneType on class hbwif.FixedWidthData: constructor has parameters (factory) that are not both immutable and accessible. Either make all parameters immutable and accessible (vals) so cloneType can be inferred, or define a custom cloneType method.`
which was created when constructing object of `FixedWidthData`.