### PR TITLE
Chipyard compatibility

### DIFF
--- a/src/main/resources/util.v
+++ b/src/main/resources/util.v
@@ -58,6 +58,17 @@ module DifferentialToBool (
 
 endmodule
 
+module TieoffDifferential (
+    input in,
+    inout out_p,
+    inout out_n
+);
+
+    assign out_p = in;
+    assign out_n = !in;
+
+endmodule
+
 module ErrorInjector #(
     parameter per1k = 0
 ) (

--- a/src/main/resources/util.v
+++ b/src/main/resources/util.v
@@ -58,7 +58,7 @@ module DifferentialToBool (
 
 endmodule
 
-module TieoffDifferential (
+module BoolToDifferential (
     input in,
     inout out_p,
     inout out_n

--- a/src/main/scala/Debug.scala
+++ b/src/main/scala/Debug.scala
@@ -2,7 +2,6 @@ package hbwif
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.RawModule
 import scala.collection.mutable.ArraySeq
 
 

--- a/src/main/scala/Encoding.scala
+++ b/src/main/scala/Encoding.scala
@@ -2,7 +2,6 @@ package hbwif
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{withClockAndReset, MultiIOModule}
 import scala.math.max
 
 // TODO get rid of this rocketchip dependency
@@ -16,7 +15,7 @@ abstract class DecodedSymbol(val decodedWidth: Int, val encodedWidth: Int, val r
     // Comparison
     def ===(other: DecodedSymbol): Bool = {
         if (this.decodedWidth == other.decodedWidth) {
-            this.toBits === other.toBits
+            this.asUInt === other.asUInt
         } else {
             false.B
         }

--- a/src/main/scala/Encoding8b10b.scala
+++ b/src/main/scala/Encoding8b10b.scala
@@ -227,7 +227,7 @@ class Decoder8b10b(decodedSymbolsPerCycle: Int) extends Decoder(decodedSymbolsPe
 
     val prev = Reg(UInt(9.W))
     val extended = Cat(prev, io.encoded.bits)
-    val offsets = Vec( (0 to 9).map { i => extended(decodedSymbolsPerCycle*10+i-1, i) } )
+    val offsets = VecInit( (0 to 9).map { i => extended(decodedSymbolsPerCycle*10+i-1, i) } )
     // Check that bits cdeif (7,3) are the same (this defines a comma)
     val commas = offsets.map { x => (x(9,3) === "b0011111".U) || (x(9,3) === "b1100000".U) }
     val found = commas.reduce(_||_)

--- a/src/main/scala/Lane.scala
+++ b/src/main/scala/Lane.scala
@@ -2,7 +2,6 @@ package hbwif
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{MultiIOModule}
 
 final class LaneIO[T <: Data](val dataFactory: () => T)(implicit val c: SerDesConfig)
     extends Bundle with TransceiverOuterIF {

--- a/src/main/scala/Packetization.scala
+++ b/src/main/scala/Packetization.scala
@@ -2,7 +2,6 @@ package hbwif
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.MultiIOModule
 
 class PacketizerIO[S <: DecodedSymbol, T <: Data](val decodedSymbolsPerCycle: Int, val symbolFactory: () => S, val dataFactory: () => T) extends Bundle {
     val symbolsTx = Vec(decodedSymbolsPerCycle, Valid(symbolFactory()))

--- a/src/main/scala/Util.scala
+++ b/src/main/scala/Util.scala
@@ -44,7 +44,7 @@ class Packer(entries: Int, width: Int = 8) extends Module {
     })
 
     io.out := (1 until entries).foldLeft(io.in)({ (prev, stage) =>
-        Vec((0 until entries).map({ i =>
+        VecInit((0 until entries).map({ i =>
             if (i >= entries - stage) {
                 prev(i)
             } else {
@@ -71,7 +71,7 @@ object Pack {
     def apply(bits: UInt, mask: UInt): (Vec[UInt], UInt) = {
         val w = bits.getWidth / mask.getWidth
         require(bits.getWidth % mask.getWidth == 0)
-        this.apply(Vec((0 until mask.getWidth).map({ i =>
+        this.apply(VecInit((0 until mask.getWidth).map({ i =>
             val v = Wire(Valid(UInt(w.W)))
             v.bits := bits(w * i + w - 1, w * i)
             v.valid := mask(i)

--- a/src/main/scala/tilelink/TLLane.scala
+++ b/src/main/scala/tilelink/TLLane.scala
@@ -3,7 +3,7 @@ package hbwif.tilelink
 import hbwif._
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{withReset, MultiIOModule, IO}
+import chisel3.experimental.IO
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.config._

--- a/src/main/scala/tilelink/Util.scala
+++ b/src/main/scala/tilelink/Util.scala
@@ -168,27 +168,27 @@ trait TLPacketizerUtils {
         val ret = Wire(UInt())
         when (tlType === typeA) {
             val a = Wire(new TLBundleA(aceEdge.bundle))
-            a := a.fromBits(0.U)
+            a := 0.U.asTypeOf(a)
             a.opcode := opcode
             ret := getNumSymbols(aceEdge, a, first)
         } .elsewhen (tlType === typeB) {
             val b = Wire(new TLBundleB(bdEdge.bundle))
-            b := b.fromBits(0.U)
+            b := 0.U.asTypeOf(b)
             b.opcode := opcode
             ret := getNumSymbols(bdEdge, b, first)
         } .elsewhen (tlType === typeC) {
             val c = Wire(new TLBundleC(aceEdge.bundle))
-            c := c.fromBits(0.U)
+            c := 0.U.asTypeOf(c)
             c.opcode := opcode
             ret := getNumSymbols(aceEdge, c, first)
         } .elsewhen (tlType === typeD) {
             val d = Wire(new TLBundleD(bdEdge.bundle))
-            d := d.fromBits(0.U)
+            d := 0.U.asTypeOf(d)
             d.opcode := opcode
             ret := getNumSymbols(bdEdge, d, first)
         } .otherwise {
             val e = Wire(new TLBundleE(aceEdge.bundle))
-            e := e.fromBits(0.U)
+            e := 0.U.asTypeOf(e)
             ret := getNumSymbols(aceEdge, e, first)
         }
         ret

--- a/src/main/scala/unittest/Encoding8b10bTest.scala
+++ b/src/main/scala/unittest/Encoding8b10bTest.scala
@@ -56,7 +56,7 @@ class Symbol8b10bGenerator(val decodedSymbolsPerCycle: Int, val symbols: Seq[(In
         val decodedReady = Input(Bool())
     })
 
-    val symbolVec = Vec(symbols map { case x => Decoded8b10bSymbol(x) })
+    val symbolVec = VecInit(symbols map { case x => Decoded8b10bSymbol(x) })
     val counter = Counter(symbols.length / decodedSymbolsPerCycle + 1)
     val initCounter = Counter(5)
     val finished = RegInit(false.B)
@@ -105,7 +105,7 @@ class Symbol8b10bChecker(val decodedSymbolsPerCycle: Int, val symbols: Seq[(Int,
     val finished = RegInit(false.B)
     io.finished := finished
 
-    val decodedRev = Vec(io.decoded.reverse)
+    val decodedRev = VecInit(io.decoded.reverse)
 
     val started = RegInit(false.B)
     val startIdx = Reg(UInt(log2Ceil(decodedSymbolsPerCycle).W))
@@ -114,7 +114,7 @@ class Symbol8b10bChecker(val decodedSymbolsPerCycle: Int, val symbols: Seq[(Int,
 
     val error = RegInit(false.B)
 
-    val symbolVec = Vec(symbols map { case x => Decoded8b10bSymbol(x) })
+    val symbolVec = VecInit(symbols map { case x => Decoded8b10bSymbol(x) })
     val idx = (counter.value * decodedSymbolsPerCycle.U) - startIdx
 
     when (started) {

--- a/src/main/scala/unittest/FixedWidthLaneTest.scala
+++ b/src/main/scala/unittest/FixedWidthLaneTest.scala
@@ -33,7 +33,7 @@ class FixedWidthLane8b10bTest[F <: Data](delay: Int, dataWidth: Int, fwDataFacto
 
     val rnd = new Random(5)
     val len = 500
-    val numBits = lane.io.data.tx.bits.toBits.getWidth
+    val numBits = lane.io.data.tx.bits.asUInt.getWidth
     val seq = Seq.fill(len) { BigInt(numBits, rnd) }
 
     val pusher = Module(new BigPusher(seq, fwDataFactory))
@@ -63,7 +63,7 @@ class BigPusher[F <: Data](seq: Seq[BigInt], fwDataFactory: () => F) extends Mod
         }
     }
 
-    io.out.bits := io.out.bits.fromBits(0.U)
+    io.out.bits := 0.U.asTypeOf(io.out.bits)
 
     seq.zipWithIndex.foreach { case (d, i) => println(f"Packet $i%d should be $d%x") }
 
@@ -73,7 +73,7 @@ class BigPusher[F <: Data](seq: Seq[BigInt], fwDataFactory: () => F) extends Mod
                 printf("Setting %x for packet %d\n", d.U, i.U)
                 printf("Set pusher.io.out.bits to %x", io.out.bits.asUInt)
             }
-            io.out.bits := io.out.bits.fromBits(d.U)
+            io.out.bits := d.U.asTypeOf(io.out.bits)
         }
     }
 
@@ -104,7 +104,7 @@ class BigChecker[F <: Data](seq: Seq[BigInt], fwDataFactory: () => F) extends Mo
         when (count.value === i.U && io.in.fire()) {
             printf("Checking that we got %x for packet %d\n", d.U, i.U)
             printf("Got checker.io.in.bits %x\n", io.in.bits.asUInt)
-            assert(io.in.bits.asUInt === io.in.bits.fromBits(d.U).asUInt, "Got the wrong data")
+            assert(io.in.bits.asUInt === d.U.asTypeOf(io.in.bits).asUInt, "Got the wrong data")
         }
     }
 

--- a/src/main/scala/unittest/Generator.scala
+++ b/src/main/scala/unittest/Generator.scala
@@ -3,7 +3,7 @@ package hbwif
 import freechips.rocketchip.util.GeneratorApp
 
 object Generator extends GeneratorApp {
-    val longName = names.topModuleProject + "." + names.topModuleClass + "." + names.configs
+    override lazy val longName = names.topModuleProject + "." + names.topModuleClass + "." + names.configs
     generateFirrtl
     generateAnno
 }

--- a/src/main/scala/unittest/TLControllerTest.scala
+++ b/src/main/scala/unittest/TLControllerTest.scala
@@ -20,9 +20,9 @@ class TLControllerPusher(edge: TLEdgeOut, pattern: Seq[Pattern])(implicit p: Par
 
     io.tl.b.ready := true.B
     io.tl.c.valid := false.B
-    io.tl.c.bits := io.tl.c.bits.fromBits(0.U)
+    io.tl.c.bits := 0.U.asTypeOf(io.tl.c.bits)
     io.tl.e.valid := false.B
-    io.tl.e.bits := io.tl.e.bits.fromBits(0.U)
+    io.tl.e.bits := 0.U.asTypeOf(io.tl.e.bits)
 
     val started = RegInit(false.B)
     started := io.start || started
@@ -37,8 +37,8 @@ class TLControllerPusher(edge: TLEdgeOut, pattern: Seq[Pattern])(implicit p: Par
     val a = io.tl.a
     val d = io.tl.d
 
-    val check = Vec(pattern.map(_.dataIn.isDefined.B))(step) holdUnless a.fire()
-    val expect = Vec(pattern.map(_.dataIn.getOrElse(BigInt(0)).U))(step) holdUnless a.fire()
+    val check = VecInit(pattern.map(_.dataIn.isDefined.B))(step) holdUnless a.fire()
+    val expect = VecInit(pattern.map(_.dataIn.getOrElse(BigInt(0)).U))(step) holdUnless a.fire()
     assert(!check || !d.fire() || expect === d.bits.data)
 
     when (a.fire()) {
@@ -50,10 +50,10 @@ class TLControllerPusher(edge: TLEdgeOut, pattern: Seq[Pattern])(implicit p: Par
     }
 
     val (plegal, pbits) = pattern.map(_.bits(edge)).unzip
-    assert(end || Vec(plegal)(step), "Illegal")
+    assert(end || VecInit(plegal)(step), "Illegal")
 
     a.valid := started && ready && !end && !flight
-    a.bits := Vec(pbits)(step)
+    a.bits := VecInit(pbits)(step)
     d.ready := true.B
 
 }

--- a/src/main/scala/unittest/Util.scala
+++ b/src/main/scala/unittest/Util.scala
@@ -68,3 +68,22 @@ object ClockToDifferential {
     }
 
 }
+
+class TieoffDifferential extends BlackBox {
+
+    val io = IO(new Bundle {
+        val in = Input(Bool())
+        val out = new Differential
+    })
+
+}
+
+object TieoffDifferential {
+
+    def apply(b: Bool): Differential = {
+        val x = Module(new TieoffDifferential)
+        x.io.in <> b
+        x.io.out
+    }
+
+}

--- a/src/main/scala/unittest/Util.scala
+++ b/src/main/scala/unittest/Util.scala
@@ -69,7 +69,7 @@ object ClockToDifferential {
 
 }
 
-class TieoffDifferential extends BlackBox {
+class BoolToDifferential extends BlackBox {
 
     val io = IO(new Bundle {
         val in = Input(Bool())
@@ -78,10 +78,10 @@ class TieoffDifferential extends BlackBox {
 
 }
 
-object TieoffDifferential {
+object BoolToDifferential {
 
     def apply(b: Bool): Differential = {
-        val x = Module(new TieoffDifferential)
+        val x = Module(new BoolToDifferential)
         x.io.in <> b
         x.io.out
     }


### PR DESCRIPTION
Chipyard 1.1.0 uses a new Chisel & Rocketchip, so:
* some module types are no longer experimental
* `toBits` -> `asUInt`, `fromBits` -> `asTypeOf`
* Some `Vec`s are now `VecInit`s

Also add Abe's tieoff bbox.