### PR TITLE
register select data before do ROM lookup to help timing

### DIFF
--- a/src/main/scala/Encoding8b10b.scala
+++ b/src/main/scala/Encoding8b10b.scala
@@ -241,8 +241,10 @@ class Decoder8b10b(decodedSymbolsPerCycle: Int) extends Decoder(decodedSymbolsPe
         prev := io.encoded.bits(8,0)
     }
 
+    val valid = (io.encoded.valid && lock)
     (0 until decodedSymbolsPerCycle).foreach { i =>
-        io.decoded(i) := Decoded8b10bSymbol.decode(offsets(idx)(i*10+9,i*10), rd, io.encoded.valid && lock)
+        val data = (offsets(idx)(i*10+9, i*10))
+        io.decoded(i) := Decoded8b10bSymbol.decode(data, rd, valid)
     }
 
     val error = RegInit(false.B)


### PR DESCRIPTION
```
 INFO:Xst:3226 - The RAM <Decoder8b10b/Mram_io_decoded_0_bits_bits> will be implemented as a BLOCK RAM, absorbing the following register(s): <_T_63_0_bits_bits>                                           
     -----------------------------------------------------------------------                                                                                                                               
     | ram_type           | Block                               |          |                                                                                                                               
     -----------------------------------------------------------------------                                                                                                                               
     | Port A                                                              |                                                                                                                               
     |     aspect ratio   | 1024-word x 8-bit                   |          |                                                                                                                               
     |     mode           | write-first                         |          |                                                                                                                               
     |     clkA           | connected to signal <io_rx_clk>     | rise     |                                                                                                                               
     |     weA            | connected to signal <GND>           | high     |                                                                                                                               
     |     addrA          | connected to signal <Decoder8b10b/_GEN_14<9:0>> |          |                                                                                                                   
     |     diA            | connected to signal <GND>           |          |                                                                                                                               
     |     doA            | connected to signal <_T_63_0_bits_bits> |          |                                                                                                                           
     -----------------------------------------------------------------------                                                                                                                               
     | optimization       | speed                               |          |     
```